### PR TITLE
Base benchmark

### DIFF
--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -322,13 +322,7 @@ class Simulation:
         gen = GENERATING_METHODS[self.variate]
         while True:
             votes = gen(self.base_votes, self.stbl_param)
-            xtd_votes  = add_totals(votes)
-            xtd_shares = find_xtd_shares(xtd_votes)
-            for c in range(self.num_constituencies+1):
-                for p in range(self.num_parties+1):
-                    self.aggregate_list(-1, "sim_votes", c, p, xtd_votes[c][p])
-                    self.aggregate_list(-1, "sim_shares", c, p, xtd_shares[c][p])
-
+            self.collect_votes(votes)
             yield votes
 
     def test_generated(self):
@@ -347,6 +341,14 @@ class Simulation:
             "err_avg": error(sim_shares["avg"], self.xtd_vote_shares),
             "err_var": error(sim_shares["var"], var_beta_distr)
         }
+
+    def collect_votes(self, votes):
+        xtd_votes  = add_totals(votes)
+        xtd_shares = find_xtd_shares(xtd_votes)
+        for c in range(self.num_constituencies+1):
+            for p in range(self.num_parties+1):
+                self.aggregate_list(-1, "sim_votes", c, p, xtd_votes[c][p])
+                self.aggregate_list(-1, "sim_shares", c, p, xtd_shares[c][p])
 
     def collect_measures(self, votes):
         for ruleset in range(self.num_rulesets):

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -322,7 +322,6 @@ class Simulation:
         gen = GENERATING_METHODS[self.variate]
         while True:
             votes = gen(self.base_votes, self.stbl_param)
-            self.collect_votes(votes)
             yield votes
 
     def test_generated(self):
@@ -511,6 +510,7 @@ class Simulation:
                 break
             self.iteration = i + 1
             votes = next(gen)
+            self.collect_votes(votes)
             self.collect_measures(votes)
             round_end = datetime.now()
             self.iteration_time = round_end - round_start

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -109,11 +109,11 @@ LIST_MEASURES = {
     "adj_seats":     "adjustment seats",
     "total_seats":   "constituency and adjustment seats combined",
     "seat_shares":   "total seats scaled to a total of 1 for each constituency",
-    "dev_opt":       "deviation from optimal solution",
-    "dev_law":       "deviation from official law method",
-    "dev_ind_const": "deviation from Independent Constituencies",
-    "dev_one_const": "deviation from Single Constituency",
-    "dev_all_adj":   "deviation from All Adjustment Seats"
+    # "dev_opt":       "deviation from optimal solution",
+    # "dev_law":       "deviation from official law method",
+    # "dev_ind_const": "deviation from Independent Constituencies",
+    # "dev_one_const": "deviation from Single Constituency",
+    # "dev_all_adj":   "deviation from All Adjustment Seats"
 }
 
 VOTE_MEASURES = {

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -350,6 +350,7 @@ class Simulation:
                 self.aggregate_list(-1, "sim_shares", c, p, xtd_shares[c][p])
 
     def collect_measures(self, votes):
+        self.collect_votes(votes)
         for ruleset in range(self.num_rulesets):
             election = voting.Election(self.e_rules[ruleset], votes)
             results = election.run()
@@ -510,7 +511,6 @@ class Simulation:
                 break
             self.iteration = i + 1
             votes = next(gen)
-            self.collect_votes(votes)
             self.collect_measures(votes)
             round_end = datetime.now()
             self.iteration_time = round_end - round_start

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -348,6 +348,13 @@ class Simulation:
             "err_var": error(sim_shares["var"], var_beta_distr)
         }
 
+    def collect_measures(self, votes):
+        for ruleset in range(self.num_rulesets):
+            election = voting.Election(self.e_rules[ruleset], votes)
+            results = election.run()
+            self.collect_list_measures(ruleset, results, election)
+            self.collect_general_measures(ruleset, votes, results, election)
+
     def collect_list_measures(self, ruleset, results, election):
         const_seats_alloc = add_totals(election.m_const_seats_alloc)
         total_seats_alloc = add_totals(results)
@@ -502,11 +509,7 @@ class Simulation:
                 break
             self.iteration = i + 1
             votes = next(gen)
-            for ruleset in range(self.num_rulesets):
-                election = voting.Election(self.e_rules[ruleset], votes)
-                results = election.run()
-                self.collect_list_measures(ruleset, results, election)
-                self.collect_general_measures(ruleset, votes, results, election)
+            self.collect_measures(votes)
             round_end = datetime.now()
             self.iteration_time = round_end - round_start
         self.analysis()

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -505,6 +505,8 @@ class Simulation:
     def simulate(self):
         """Simulate many elections."""
         gen = self.gen_votes()
+        if self.num_total_simulations == 0:
+            self.collect_measures(self.base_votes)
         for i in range(self.num_total_simulations):
             round_start = datetime.now()
             if self.terminate:

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -82,3 +82,24 @@ class SimulationTest(TestCase):
             self.assertEqual(measures[m]['cnt'], 1)
             self.assertEqual(measures[m]['var'], 0)
             self.assertEqual(measures[m]['std'], 0)
+
+    def test_simulate(self):
+        #Arrange
+        self.s_rules["simulation_count"] = 100
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertGreater(vote_data['sum'][const][party], 0)
+                self.assertGreater(vote_data['avg'][const][party], 0)
+                self.assertEqual(vote_data['cnt'][const][party], 100)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 100)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 100)

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -56,6 +56,37 @@ class SimulationTest(TestCase):
 
         # Verify that µ=0.5±2%
 
+    def test_simulate_not_at_all(self):
+        #Arrange
+        self.s_rules["simulation_count"] = 0
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertEqual(
+                    vote_data['sum'][const][party], self.votes[const][party]
+                )
+                self.assertEqual(
+                    vote_data['avg'][const][party], self.votes[const][party]
+                )
+                self.assertEqual(vote_data['cnt'][const][party], 1)
+                self.assertEqual(vote_data['var'][const][party], 0)
+                self.assertEqual(vote_data['std'][const][party], 0)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 1)
+                    self.assertEqual(list_measures[m]['var'][const][party], 0)
+                    self.assertEqual(list_measures[m]['std'][const][party], 0)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 1)
+            self.assertEqual(measures[m]['var'], 0)
+            self.assertEqual(measures[m]['std'], 0)
+
     def test_simulate_once(self):
         #Arrange
         self.s_rules["simulation_count"] = 1

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -54,3 +54,37 @@ class SimulationTest(TestCase):
 
 
         # Verify that µ=0.5±2%
+
+    def test_simulate_once(self):
+        #Arrange
+        s_rules = simulate.SimulationRules()
+        s_rules["simulation_count"] = 1
+        e_rules = voting.ElectionRules()
+        e_rules["constituency_names"] = ["I", "II", "III"]
+        e_rules["constituency_seats"] = [5, 6, 4]
+        e_rules["constituency_adjustment_seats"] = [1, 2, 1]
+        e_rules["parties"] = ["A", "B"]
+        votes = [[500, 300], [200, 400], [350, 450]]
+        sim = simulate.Simulation(s_rules, [e_rules], votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertGreater(vote_data['sum'][const][party], 0)
+                self.assertGreater(vote_data['avg'][const][party], 0)
+                self.assertEqual(vote_data['cnt'][const][party], 1)
+                self.assertEqual(vote_data['var'][const][party], 0)
+                self.assertEqual(vote_data['std'][const][party], 0)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 1)
+                    self.assertEqual(list_measures[m]['var'][const][party], 0)
+                    self.assertEqual(list_measures[m]['std'][const][party], 0)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 1)
+            self.assertEqual(measures[m]['var'], 0)
+            self.assertEqual(measures[m]['std'], 0)

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -10,38 +10,39 @@ import util
 
 class SimulationTest(TestCase):
     def setUp(self):
-        pass
+        self.e_rules = voting.ElectionRules()
+        self.e_rules["constituency_names"] = ["I", "II", "III"]
+        self.e_rules["constituency_seats"] = [5, 6, 4]
+        self.e_rules["constituency_adjustment_seats"] = [1, 2, 1]
+        self.e_rules["parties"] = ["A", "B"]
+        self.votes = [[500, 300], [200, 400], [350, 450]]
+        self.s_rules = simulate.SimulationRules()
+        self.s_rules["simulation_count"] = 100
 
     def test_generate_votes(self):
         pass
         # Generate a few vote sets
 
     def test_generate_votes_average(self):
-        s_rules = simulate.SimulationRules()
-        s_rules["simulation_count"] = 1000
-        e_rules = voting.ElectionRules()
-        e_rules["constituency_names"] = ["I", "II", "III"]
-        e_rules["constituency_seats"] = [5, 6, 4]
-        e_rules["constituency_adjustment_seats"] = [1, 2, 1]
-        e_rules["parties"] = ["A", "B"]
-        votes = [[500, 300], [200, 400], [350, 450]]
-        sim = simulate.Simulation(s_rules, [e_rules], votes, 100)
+        n = 1000
+        self.s_rules["simulation_count"] = n
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
         gen = sim.gen_votes()
         r = []
         r_avg = []
         r_var = []
-        for k in range(s_rules["simulation_count"]):
+        for k in range(n):
             r.append([])
             generated_votes = next(gen)
-            for i in range(len(votes)):
+            for i in range(len(self.votes)):
                 r[k].append([])
-                for j in range(len(votes[i])):
+                for j in range(len(self.votes[i])):
                     r[k][i].append(uniform(0.0,1.0))
-        for i in range(len(votes)):
+        for i in range(len(self.votes)):
             r_avg.append([])
             r_var.append([])
-            for j in range(len(votes[i])):
-                r_ij = [r[k][i][j] for k in range(s_rules["simulation_count"])]
+            for j in range(len(self.votes[i])):
+                r_ij = [r[k][i][j] for k in range(n)]
                 # average = simulate.avg(r_ij)
                 # r_avg[i].append(average)
                 # r_var[i].append(simulate.var(r_ij, average))
@@ -57,15 +58,8 @@ class SimulationTest(TestCase):
 
     def test_simulate_once(self):
         #Arrange
-        s_rules = simulate.SimulationRules()
-        s_rules["simulation_count"] = 1
-        e_rules = voting.ElectionRules()
-        e_rules["constituency_names"] = ["I", "II", "III"]
-        e_rules["constituency_seats"] = [5, 6, 4]
-        e_rules["constituency_adjustment_seats"] = [1, 2, 1]
-        e_rules["parties"] = ["A", "B"]
-        votes = [[500, 300], [200, 400], [350, 450]]
-        sim = simulate.Simulation(s_rules, [e_rules], votes, 100)
+        self.s_rules["simulation_count"] = 1
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
         #Act
         sim.simulate()
         #Assert


### PR DESCRIPTION
Add functionality for applying the measurements we have been using for the simulated results to the results of a single Election, to use as a benchmark for the measurements themselves.